### PR TITLE
Fix datatype for vcl::backend timeouts

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1390,7 +1390,7 @@ Default value: `undef`
 
 ##### <a name="-varnish--vcl--backend--connect_timeout"></a>`connect_timeout`
 
-Data type: `Optional[Integer]`
+Data type: `Optional[Variant[String[1],Integer]]`
 
 define varnish connect connect_timeout
 
@@ -1398,7 +1398,7 @@ Default value: `undef`
 
 ##### <a name="-varnish--vcl--backend--first_byte_timeout"></a>`first_byte_timeout`
 
-Data type: `Optional[Integer]`
+Data type: `Optional[Variant[String[1],Integer]]`
 
 define varnish first_byte_timeout
 
@@ -1406,7 +1406,7 @@ Default value: `undef`
 
 ##### <a name="-varnish--vcl--backend--between_bytes_timeout"></a>`between_bytes_timeout`
 
-Data type: `Optional[Integer]`
+Data type: `Optional[Variant[String[1],Integer]]`
 
 define varnish between_bytes_timeout
 

--- a/manifests/vcl/backend.pp
+++ b/manifests/vcl/backend.pp
@@ -16,9 +16,9 @@ define varnish::vcl::backend (
   Stdlib::Host  $host,
   Stdlib::Port  $port,
   Optional[String]  $probe                 = undef,
-  Optional[Integer] $connect_timeout       = undef,
-  Optional[Integer] $first_byte_timeout    = undef,
-  Optional[Integer] $between_bytes_timeout = undef,
+  Optional[Variant[String[1],Integer]] $connect_timeout       = undef,
+  Optional[Variant[String[1],Integer]] $first_byte_timeout    = undef,
+  Optional[Variant[String[1],Integer]] $between_bytes_timeout = undef,
 ) {
   validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in backend name ${title}. Only letters, numbers and underscore are allowed.")
 


### PR DESCRIPTION
Fix Datatype, as values like '5s' are also allowed