### PR TITLE
Define ressource type to validate instead of validate_re

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1347,13 +1347,13 @@ The following parameters are available in the `varnish::vcl::acl_member` defined
 
 ##### <a name="-varnish--vcl--acl_member--varnish_fqdn"></a>`varnish_fqdn`
 
-Data type: `String`
+Data type: `String[1]`
 
 Tag name of the varnish host that is collected
 
 ##### <a name="-varnish--vcl--acl_member--acl"></a>`acl`
 
-Data type: `String`
+Data type: `Varnish::VCL::Ressource`
 
 Name of the ACL that should be created
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -40,6 +40,7 @@
 ### Data types
 
 * [`Varnish::Controller::Agent_name`](#Varnish--Controller--Agent_name): Type for supported Agent Name of Controller Agent
+* [`Varnish::Vcl::Ressource`](#Varnish--Vcl--Ressource): Type for supported VCL Versions
 * [`Varnish::Vclversion`](#Varnish--Vclversion): Type for supported VCL Versions
 
 ## Classes
@@ -1315,22 +1316,22 @@ Defines an ACL Type of Varnish. Defined ACL's must be used in VCL
 
 The following parameters are available in the `varnish::vcl::acl` defined type:
 
-* [`hosts`](#-varnish--vcl--acl--hosts)
 * [`acl_name`](#-varnish--vcl--acl--acl_name)
+* [`hosts`](#-varnish--vcl--acl--hosts)
+
+##### <a name="-varnish--vcl--acl--acl_name"></a>`acl_name`
+
+Data type: `Varnish::VCL::Ressource`
+
+Name of ACL
+
+Default value: `$title`
 
 ##### <a name="-varnish--vcl--acl--hosts"></a>`hosts`
 
 Data type: `Array[Stdlib::IP::Address]`
 
 Array of defined Hosts
-
-##### <a name="-varnish--vcl--acl--acl_name"></a>`acl_name`
-
-Data type: `Pattern['\A[A-Za-z0-9_]+\z']`
-
-The actual ACL name
-
-Default value: `$title`
 
 ### <a name="varnish--vcl--acl_member"></a>`varnish::vcl::acl_member`
 
@@ -1392,7 +1393,7 @@ Port of the backend host
 
 ##### <a name="-varnish--vcl--backend--backend_name"></a>`backend_name`
 
-Data type: `Pattern['\A[A-Za-z0-9_]+\z']`
+Data type: `Varnish::VCL::Ressource`
 
 The actual backend name
 
@@ -1445,9 +1446,9 @@ The following parameters are available in the `varnish::vcl::director` defined t
 
 ##### <a name="-varnish--vcl--director--director_name"></a>`director_name`
 
-Data type: `Pattern['\A[A-Za-z0-9_]+\z']`
+Data type: `Varnish::VCL::Ressource`
 
-The actual director name
+Name of the director
 
 Default value: `$title`
 
@@ -1497,9 +1498,9 @@ The following parameters are available in the `varnish::vcl::probe` defined type
 
 ##### <a name="-varnish--vcl--probe--probe_name"></a>`probe_name`
 
-Data type: `Pattern['\A[A-Za-z0-9_]+\z']`
+Data type: `Varnish::VCL::Ressource`
 
-The actual probe name
+Name of the probe
 
 Default value: `$title`
 
@@ -1646,6 +1647,12 @@ Default value: `$varnish::vcl::vcl_version`
 Type for supported Agent Name of Controller Agent
 
 Alias of `Pattern[/\A(?i:([-a-z0-9]+))\z/]`
+
+### <a name="Varnish--Vcl--Ressource"></a>`Varnish::Vcl::Ressource`
+
+Type for supported VCL Versions
+
+Alias of `Pattern[/^[A-Za-z0-9_]+$/]`
 
 ### <a name="Varnish--Vclversion"></a>`Varnish::Vclversion`
 

--- a/manifests/vcl/acl.pp
+++ b/manifests/vcl/acl.pp
@@ -4,8 +4,6 @@
 #    Name of ACL
 # @param hosts
 #    Array of defined Hosts
-# @param acl_name
-#    The actual ACL name
 define varnish::vcl::acl (
   Array[Stdlib::IP::Address] $hosts,
   Varnish::VCL::Ressource $acl_name = $title,

--- a/manifests/vcl/acl.pp
+++ b/manifests/vcl/acl.pp
@@ -18,13 +18,13 @@ define varnish::vcl::acl (
       } -> concat::fragment { "${title}-acl_tail":
         target  => "${varnish::vcl::includedir}/acls.vcl",
         content => "}\n",
-        order   => "02-${acl_name}-3-0",
+        order   => "02-${title}-3-0",
       }
     }
-    concat::fragment { "${acl_name}-acl_body":
+    concat::fragment { "${title}-acl_body":
       target  => "${varnish::vcl::includedir}/acls.vcl",
       content => template('varnish/includes/acls_body.vcl.erb'),
-      order   => "02-${acl_name}-2-0",
+      order   => "02-${title}-2-0",
     }
   }
 }

--- a/manifests/vcl/acl.pp
+++ b/manifests/vcl/acl.pp
@@ -1,18 +1,19 @@
 # @summary Defines an ACL Type of Varnish. Defined ACL's must be used in VCL
 # 
+# @param acl_name
+#    Name of ACL
 # @param hosts
 #    Array of defined Hosts
 define varnish::vcl::acl (
   Array[Stdlib::IP::Address] $hosts,
+  Varnish::VCL::Ressource $acl_name = $title,
 ) {
   # Varnish does not allow empty ACLs
   if size($hosts) > 0 {
-    validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in ACL name ${title}. Only letters, numbers and underscore are allowed.")
-
     unless defined(Concat::Fragment["${title}-acl_head"]) {
       concat::fragment { "${title}-acl_head":
         target  => "${varnish::vcl::includedir}/acls.vcl",
-        content => "acl ${title} {\n",
+        content => "acl ${acl_name} {\n",
         order   => "02-${title}-1-0",
       } -> concat::fragment { "${title}-acl_tail":
         target  => "${varnish::vcl::includedir}/acls.vcl",

--- a/manifests/vcl/acl_member.pp
+++ b/manifests/vcl/acl_member.pp
@@ -7,8 +7,8 @@
 # @param host
 #   Host ip that will be inserted
 define varnish::vcl::acl_member (
-  String $varnish_fqdn,
-  String $acl,
+  String[1] $varnish_fqdn,
+  Varnish::VCL::Ressource $acl,
   Stdlib::IP::Address $host,
 ) {
   unless defined(Concat::Fragment["${acl}-acl_head"]) {

--- a/manifests/vcl/backend.pp
+++ b/manifests/vcl/backend.pp
@@ -1,7 +1,5 @@
 # @summary Defines a Backend for VCL
 #
-# @param backend_name
-#    Name of the Backend
 # @param host
 #   Host that will be defined as backend
 # @param port
@@ -19,7 +17,6 @@
 define varnish::vcl::backend (
   Stdlib::Host  $host,
   Stdlib::Port  $port,
-  Pattern['\A[A-Za-z0-9_]+\z'] $backend_name = $title,
   Optional[String]  $probe                 = undef,
   Optional[Variant[String[1],Integer]] $connect_timeout       = undef,
   Optional[Variant[String[1],Integer]] $first_byte_timeout    = undef,

--- a/manifests/vcl/backend.pp
+++ b/manifests/vcl/backend.pp
@@ -1,5 +1,7 @@
 # @summary Defines a Backend for VCL
 #
+# @param backend_name
+#    Name of the Backend
 # @param host
 #   Host that will be defined as backend
 # @param port
@@ -19,9 +21,8 @@ define varnish::vcl::backend (
   Optional[Variant[String[1],Integer]] $connect_timeout       = undef,
   Optional[Variant[String[1],Integer]] $first_byte_timeout    = undef,
   Optional[Variant[String[1],Integer]] $between_bytes_timeout = undef,
+  Varnish::VCL::Ressource $backend_name = $title,
 ) {
-  validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in backend name ${title}. Only letters, numbers and underscore are allowed.")
-
   concat::fragment { "${title}-backend":
     target  => "${varnish::vcl::includedir}/backends.vcl",
     content => template('varnish/includes/backends.vcl.erb'),

--- a/manifests/vcl/director.pp
+++ b/manifests/vcl/director.pp
@@ -36,7 +36,7 @@ define varnish::vcl::director (
     }
   }
 
-  concat::fragment { "${director_name}-director":
+  concat::fragment { "${title}-director":
     target  => "${varnish::vcl::includedir}/directors.vcl",
     content => template($template_director),
     order   => '02',

--- a/manifests/vcl/director.pp
+++ b/manifests/vcl/director.pp
@@ -1,5 +1,7 @@
 # @summary Defines a backend director in varnish vcl
 #
+# @param director_name
+#    Name of the director
 # @param type
 #   Type of varnish backend director
 # @param backends
@@ -9,10 +11,9 @@
 define varnish::vcl::director (
   String $type = 'round-robin',
   Array[String] $backends = [],
-  Varnish::Vclversion $vcl_version = $varnish::vcl::vcl_version
+  Varnish::Vclversion $vcl_version = $varnish::vcl::vcl_version,
+  Varnish::VCL::Ressource $director_name = $title,
 ) {
-  validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in director name ${title}. Only letters, numbers and underscore are allowed.")
-
   case $vcl_version {
     '4': {
       $template_director = 'varnish/includes/directors4.vcl.erb'

--- a/manifests/vcl/director.pp
+++ b/manifests/vcl/director.pp
@@ -9,7 +9,6 @@
 # @param vcl_version
 #   Version of vcl Language
 define varnish::vcl::director (
-  Pattern['\A[A-Za-z0-9_]+\z'] $director_name = $title,
   String $type = 'round-robin',
   Array[String] $backends = [],
   Varnish::Vclversion $vcl_version = $varnish::vcl::vcl_version,

--- a/manifests/vcl/probe.pp
+++ b/manifests/vcl/probe.pp
@@ -33,7 +33,7 @@ define varnish::vcl::probe (
   # parameters for probe
   $probe_params = ['interval', 'timeout', 'threshold', 'window', 'url', 'request']
 
-  concat::fragment { "${probe_name}-probe":
+  concat::fragment { "${title}-probe":
     target  => "${includedir}/probes.vcl",
     content => template('varnish/includes/probes.vcl.erb'),
     order   => '02',

--- a/manifests/vcl/probe.pp
+++ b/manifests/vcl/probe.pp
@@ -21,7 +21,6 @@
 # @param request
 #   Paramter as defined from varnish
 define varnish::vcl::probe (
-  Pattern['\A[A-Za-z0-9_]+\z'] $probe_name = $title,
   String $interval  = '5s',
   String $timeout   = '5s',
   String $threshold = '3',

--- a/manifests/vcl/probe.pp
+++ b/manifests/vcl/probe.pp
@@ -4,6 +4,8 @@
 #
 # @see https://varnish-cache.org/docs/trunk/reference/vcl-probe.html
 #
+# @param probe_name
+#    Name of the probe
 # @param interval
 #   Paramter as defined from varnish
 # @param timeout
@@ -26,9 +28,8 @@ define varnish::vcl::probe (
   String $includedir = $varnish::vcl::includedir,
   Optional[String] $url       = undef,
   Optional[Variant[String,Array[String]]] $request   = undef,
+  Varnish::VCL::Ressource $probe_name = $title,
 ) {
-  validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in probe name ${title}. Only letters, numbers and underscore are allowed.")
-
   # parameters for probe
   $probe_params = ['interval', 'timeout', 'threshold', 'window', 'url', 'request']
 

--- a/spec/defines/varnish_vcl_acl_spec.rb
+++ b/spec/defines/varnish_vcl_acl_spec.rb
@@ -22,7 +22,6 @@ describe 'varnish::vcl::acl', type: :define do
       let(:params) { { hosts: ['192.168.10.14'] } }
 
       context('expected behaviour') do
-
         it { is_expected.to contain_concat__fragment('foo-acl_body').with_target('/etc/varnish/includes/acls.vcl') }
         it { is_expected.to contain_concat__fragment('foo-acl_body').with_content(%r{^\s+"192.168.10.14";\s+$}) }
         it { is_expected.to contain_concat__fragment('foo-acl_head').with_target('/etc/varnish/includes/acls.vcl') }

--- a/spec/defines/varnish_vcl_acl_spec.rb
+++ b/spec/defines/varnish_vcl_acl_spec.rb
@@ -19,8 +19,9 @@ describe 'varnish::vcl::acl', type: :define do
         facts
       end
 
+      let(:params) { { hosts: ['192.168.10.14'] } }
+
       context('expected behaviour') do
-        let(:params) { { hosts: ['192.168.10.14'] } }
 
         it { is_expected.to contain_concat__fragment('foo-acl_body').with_target('/etc/varnish/includes/acls.vcl') }
         it { is_expected.to contain_concat__fragment('foo-acl_body').with_content(%r{^\s+"192.168.10.14";\s+$}) }
@@ -32,11 +33,16 @@ describe 'varnish::vcl::acl', type: :define do
 
       context('invalid acl title') do
         let(:title) { '-wrong_title' }
-        let(:params) { { hosts: ['192.168.10.14'] } }
 
         it 'causes a failure' do
-          is_expected.to compile.and_raise_error(%r{Invalid characters in ACL name -wrong_title. Only letters, numbers and underscore are allowed.})
+          is_expected.to compile.and_raise_error(%r{.*})
         end
+      end
+
+      context('title != acl_name') do
+        let(:params) { super().merge('acl_name' => 'bar') }
+
+        it { is_expected.to contain_concat__fragment('foo-acl_head').with_content(%r{^acl bar \{$}) }
       end
     end
   end

--- a/spec/defines/varnish_vcl_backend_spec.rb
+++ b/spec/defines/varnish_vcl_backend_spec.rb
@@ -40,6 +40,20 @@ describe 'varnish::vcl::backend', type: :define do
           is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.between_bytes_timeout = 5s;})
         }
       end
+
+      context('invalid title') do
+        let(:title) { '-wrong_title' }
+
+        it 'causes a failure' do
+          is_expected.to compile.and_raise_error(%r{.*})
+        end
+      end
+
+      context('title != backend_name') do
+        let(:params) { super().merge('backend_name' => 'bar') }
+
+        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{backend bar \{}) }
+      end
     end
   end
 end

--- a/spec/defines/varnish_vcl_director_spec.rb
+++ b/spec/defines/varnish_vcl_director_spec.rb
@@ -16,13 +16,26 @@ describe 'varnish::vcl::director', type: :define do
       let :facts do
         facts
       end
+      let(:params) { { backends: ['192.168.10.14'] } }
 
       context('expected behaviour') do
-        let(:params) { { backends: ['192.168.10.14'] } }
-
         it {
           is_expected.to contain_concat__fragment('foo-director').with_content(%r{new foo})
         }
+      end
+
+      context('invalid title') do
+        let(:title) { '-wrong_title' }
+
+        it 'causes a failure' do
+          is_expected.to compile.and_raise_error(%r{.*})
+        end
+      end
+
+      context('title != director_name') do
+        let(:params) { super().merge('director_name' => 'bar') }
+
+        it { is_expected.to contain_concat__fragment('foo-director').with_content(%r{new bar}) }
       end
     end
   end

--- a/spec/defines/varnish_vcl_probe_spec.rb
+++ b/spec/defines/varnish_vcl_probe_spec.rb
@@ -19,6 +19,21 @@ describe 'varnish::vcl::probe', type: :define do
   context('expected behaviour') do
     it {
       is_expected.to contain_concat__fragment('foo-probe').with_target('/etc/varnish/includes/probes.vcl')
+      is_expected.to contain_concat__fragment('foo-probe').with_content(%r{probe foo \{})
     }
+  end
+
+  context('invalid title') do
+    let(:title) { '-wrong_title' }
+
+    it 'causes a failure' do
+      is_expected.to compile.and_raise_error(%r{.*})
+    end
+  end
+
+  context('title != probe_name') do
+    let(:params) { super().merge('probe_name' => 'bar') }
+
+    it { is_expected.to contain_concat__fragment('foo-probe').with_content(%r{probe bar \{}) }
   end
 end

--- a/spec/type_aliases/vclressouce_spec.rb
+++ b/spec/type_aliases/vclressouce_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Varnish::Vcl::Ressource' do
+  describe 'valid handling' do
+    %w[
+      test
+      test1234
+      123_asd
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'invalid handling' do
+    context 'garbage inputs' do
+      [
+        [nil],
+        [nil, nil],
+        { 'foo' => 'bar' },
+        {},
+        '',
+        '4-2',
+        'asd/',
+        'bob@example.com',
+        '%.example.com',
+        '2001:0d8',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/templates/includes/backends.vcl.erb
+++ b/templates/includes/backends.vcl.erb
@@ -1,5 +1,5 @@
-# set backend <%= @title %>
-backend <%= @title %> {
+# set backend <%= @backend_name %>
+backend <%= @backend_name %> {
   .host = "<%= @host %>";
   .port = "<%= @port %>";
   <%- if @probe -%>

--- a/templates/includes/directors.vcl.erb
+++ b/templates/includes/directors.vcl.erb
@@ -1,5 +1,5 @@
 # set director <%= @title %>
-director <%= @title -%> <%= @type -%> {
+director <%= @director_name -%> <%= @type -%> {
   <%- @backends.each do |backend| -%>
   { .backend = <%= backend -%>; }
   <%- end -%>

--- a/templates/includes/directors4.vcl.erb
+++ b/templates/includes/directors4.vcl.erb
@@ -1,5 +1,5 @@
 # set director <%= @title %>
-  new <%= @title -%> = directors.<%= @director_object -%>();
+  new <%= @director_name -%> = directors.<%= @director_object -%>();
   <%- @backends.each do |backend| -%>
 <%- if @director_object == 'hash' || @director_object == 'random' -%>
   <%= @title -%>.add_backend(<%= backend -%>, 1.0);

--- a/templates/includes/probes.vcl.erb
+++ b/templates/includes/probes.vcl.erb
@@ -1,5 +1,5 @@
 # set probe <%= @title %>
-probe <%= @title -%> {
+probe <%= @probe_name -%> {
   <%- @probe_params.each do |param| -%>
     <%- next unless instance_variable_get("@#{param}") -%>
     <%- if param == 'url' -%>

--- a/types/vcl/ressource.pp
+++ b/types/vcl/ressource.pp
@@ -1,0 +1,2 @@
+#Type for supported VCL Versions
+type Varnish::Vcl::Ressource = Pattern[/^[A-Za-z0-9_]+$/]


### PR DESCRIPTION
validate_re has been used to validate the correct Ressouce names.

This will be Replaced through correct type. Also allows to set the vcl type name independent from puppet title
