### PR TITLE
Drop debian 9 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -63,7 +63,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10",
         "11"
       ]


### PR DESCRIPTION
Debian 9 is EOL, so drop support for it