### PR TITLE
Add varnish-plus Backend parameters to use with ssl

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1387,6 +1387,12 @@ The following parameters are available in the `varnish::vcl::backend` defined ty
 * [`connect_timeout`](#-varnish--vcl--backend--connect_timeout)
 * [`first_byte_timeout`](#-varnish--vcl--backend--first_byte_timeout)
 * [`between_bytes_timeout`](#-varnish--vcl--backend--between_bytes_timeout)
+* [`ssl`](#-varnish--vcl--backend--ssl)
+* [`ssl_sni`](#-varnish--vcl--backend--ssl_sni)
+* [`ssl_verify_peer`](#-varnish--vcl--backend--ssl_verify_peer)
+* [`ssl_verify_host`](#-varnish--vcl--backend--ssl_verify_host)
+* [`host_header`](#-varnish--vcl--backend--host_header)
+* [`certificate`](#-varnish--vcl--backend--certificate)
 
 ##### <a name="-varnish--vcl--backend--host"></a>`host`
 
@@ -1437,6 +1443,54 @@ Default value: `undef`
 Data type: `Optional[Variant[String[1],Integer]]`
 
 define varnish between_bytes_timeout
+
+Default value: `undef`
+
+##### <a name="-varnish--vcl--backend--ssl"></a>`ssl`
+
+Data type: `Optional[Integer[0,1]]`
+
+varnish-plus: Set this true (1) to enable SSL/TLS for this backend.
+
+Default value: `undef`
+
+##### <a name="-varnish--vcl--backend--ssl_sni"></a>`ssl_sni`
+
+Data type: `Optional[Integer[0,1]]`
+
+varnish-plus: Set this to false (0) to disable the use of the Server Name Indication (SNI) extension for backend TLS connections
+
+Default value: `undef`
+
+##### <a name="-varnish--vcl--backend--ssl_verify_peer"></a>`ssl_verify_peer`
+
+Data type: `Optional[Integer[0,1]]`
+
+varnish-plus: Set this to false (0) to disable verification of the peer’s certificate chain.
+
+Default value: `undef`
+
+##### <a name="-varnish--vcl--backend--ssl_verify_host"></a>`ssl_verify_host`
+
+Data type: `Optional[Integer[0,1]]`
+
+varnish-plus: Set this to true (1) to enable verification of the peer’s certificate identity
+
+Default value: `undef`
+
+##### <a name="-varnish--vcl--backend--host_header"></a>`host_header`
+
+Data type: `Optional[String[1]]`
+
+varnish-plus: A host header to add to probes and regular backend requests if they have no such header
+
+Default value: `undef`
+
+##### <a name="-varnish--vcl--backend--certificate"></a>`certificate`
+
+Data type: `Optional[String[1]]`
+
+varnish-plus: Specifies a client certificate to be used
 
 Default value: `undef`
 

--- a/manifests/vcl/backend.pp
+++ b/manifests/vcl/backend.pp
@@ -14,6 +14,18 @@
 #   define varnish first_byte_timeout
 # @param between_bytes_timeout
 #   define varnish between_bytes_timeout
+# @param ssl
+#   varnish-plus: Set this true (1) to enable SSL/TLS for this backend.
+# @param ssl_sni
+#   varnish-plus: Set this to false (0) to disable the use of the Server Name Indication (SNI) extension for backend TLS connections
+# @param ssl_verify_peer
+#   varnish-plus: Set this to false (0) to disable verification of the peer’s certificate chain.
+# @param ssl_verify_host
+#   varnish-plus: Set this to true (1) to enable verification of the peer’s certificate identity
+# @param host_header
+#   varnish-plus: A host header to add to probes and regular backend requests if they have no such header
+# @param certificate
+#   varnish-plus: Specifies a client certificate to be used
 define varnish::vcl::backend (
   Stdlib::Host  $host,
   Stdlib::Port  $port,
@@ -21,6 +33,12 @@ define varnish::vcl::backend (
   Optional[Variant[String[1],Integer]] $connect_timeout       = undef,
   Optional[Variant[String[1],Integer]] $first_byte_timeout    = undef,
   Optional[Variant[String[1],Integer]] $between_bytes_timeout = undef,
+  Optional[Integer[0,1]] $ssl = undef,
+  Optional[Integer[0,1]] $ssl_sni = undef,
+  Optional[Integer[0,1]] $ssl_verify_peer = undef,
+  Optional[Integer[0,1]] $ssl_verify_host = undef,
+  Optional[String[1]] $host_header = undef,
+  Optional[String[1]] $certificate = undef,
   Varnish::VCL::Ressource $backend_name = $title,
 ) {
   concat::fragment { "${title}-backend":

--- a/spec/defines/varnish_vcl_backend_spec.rb
+++ b/spec/defines/varnish_vcl_backend_spec.rb
@@ -38,6 +38,12 @@ describe 'varnish::vcl::backend', type: :define do
           is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.connect_timeout = 5s;})
           is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.first_byte_timeout = 10m;})
           is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.between_bytes_timeout = 5s;})
+          is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl = .*;})
+          is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_sni = .*;})
+          is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_verify_peer = .*;})
+          is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_verify_host = .*;})
+          is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.host_header = .*;})
+          is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.host_header = .*;})
         }
       end
 
@@ -56,9 +62,23 @@ describe 'varnish::vcl::backend', type: :define do
       end
 
       context('ssl params') do
-        let(:params) { super().merge('ssl' => 1) }
+        let(:params) do
+          super().merge(
+            'ssl' => 1,
+            'ssl_sni' => 1,
+            'ssl_verify_peer' => 1,
+            'ssl_verify_host' => 1,
+            'host_header' => 'foobar',
+            'certificate' => 'foobar'
+          )
+        end
 
         it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl = 1;}) }
+        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_sni = 1;}) }
+        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_verify_peer = 1;}) }
+        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_verify_host = 1;}) }
+        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.host_header = "foobar";}) }
+        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.host_header = "foobar";}) }
       end
     end
   end

--- a/spec/defines/varnish_vcl_backend_spec.rb
+++ b/spec/defines/varnish_vcl_backend_spec.rb
@@ -43,7 +43,7 @@ describe 'varnish::vcl::backend', type: :define do
           is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_verify_peer = .*;})
           is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_verify_host = .*;})
           is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.host_header = .*;})
-          is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.host_header = .*;})
+          is_expected.not_to contain_concat__fragment('foo-backend').with_content(%r{\s+.certificate = .*;})
         }
       end
 
@@ -78,7 +78,7 @@ describe 'varnish::vcl::backend', type: :define do
         it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_verify_peer = 1;}) }
         it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl_verify_host = 1;}) }
         it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.host_header = "foobar";}) }
-        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.host_header = "foobar";}) }
+        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.certificate = "foobar";}) }
       end
     end
   end

--- a/spec/defines/varnish_vcl_backend_spec.rb
+++ b/spec/defines/varnish_vcl_backend_spec.rb
@@ -54,6 +54,12 @@ describe 'varnish::vcl::backend', type: :define do
 
         it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{backend bar \{}) }
       end
+
+      context('ssl params') do
+        let(:params) { super().merge('ssl' => 1) }
+
+        it { is_expected.to contain_concat__fragment('foo-backend').with_content(%r{\s+.ssl = 1;}) }
+      end
     end
   end
 end

--- a/templates/includes/backends.vcl.erb
+++ b/templates/includes/backends.vcl.erb
@@ -15,21 +15,21 @@ backend <%= @backend_name %> {
   .between_bytes_timeout = <% if @between_bytes_timeout.is_a? Integer %><%= "#{@between_bytes_timeout}s" %><% else %><%= @between_bytes_timeout %><% end %>;
   <%- end -%>
   <%- if @ssl -%>
-  .ssl = <%= @ssl %>;;
+  .ssl = <%= @ssl %>;
   <%- end -%>
   <%- if @ssl_sni -%>
-  .ssl_sni = <%= @ssl_sni %>;;
+  .ssl_sni = <%= @ssl_sni %>;
   <%- end -%>
   <%- if @ssl_verify_peer -%>
-  .ssl_verify_peer = <%= @ssl_verify_peer %>;;
+  .ssl_verify_peer = <%= @ssl_verify_peer %>;
   <%- end -%>
   <%- if @ssl_verify_host -%>
-  .ssl_verify_host = <%= @ssl_verify_host %>;;
+  .ssl_verify_host = <%= @ssl_verify_host %>;
   <%- end -%>
   <%- if @host_header -%>
-  .host_header = <%= @host_header %>;;
+  .host_header = "<%= @host_header %>";
   <%- end -%>
   <%- if @certificate -%>
-  .certificate = <%= @certificate %>;;
+  .certificate = "<%= @certificate %>";
   <%- end -%>
 }

--- a/templates/includes/backends.vcl.erb
+++ b/templates/includes/backends.vcl.erb
@@ -14,4 +14,22 @@ backend <%= @backend_name %> {
   <%- if @between_bytes_timeout -%>
   .between_bytes_timeout = <% if @between_bytes_timeout.is_a? Integer %><%= "#{@between_bytes_timeout}s" %><% else %><%= @between_bytes_timeout %><% end %>;
   <%- end -%>
+  <%- if @ssl -%>
+  .ssl = <%= @ssl %>;;
+  <%- end -%>
+  <%- if @ssl_sni -%>
+  .ssl_sni = <%= @ssl_sni %>;;
+  <%- end -%>
+  <%- if @ssl_verify_peer -%>
+  .ssl_verify_peer = <%= @ssl_verify_peer %>;;
+  <%- end -%>
+  <%- if @ssl_verify_host -%>
+  .ssl_verify_host = <%= @ssl_verify_host %>;;
+  <%- end -%>
+  <%- if @host_header -%>
+  .host_header = <%= @host_header %>;;
+  <%- end -%>
+  <%- if @certificate -%>
+  .certificate = <%= @certificate %>;;
+  <%- end -%>
 }


### PR DESCRIPTION
Add definition to use ssl params defined in 
https://docs.varnish-software.com/varnish-enterprise/features/backend-ssl/
