### PR TITLE
add expected_response parameter for probes

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1558,6 +1558,7 @@ The following parameters are available in the `varnish::vcl::probe` defined type
 * [`includedir`](#-varnish--vcl--probe--includedir)
 * [`url`](#-varnish--vcl--probe--url)
 * [`request`](#-varnish--vcl--probe--request)
+* [`expected_response`](#-varnish--vcl--probe--expected_response)
 
 ##### <a name="-varnish--vcl--probe--probe_name"></a>`probe_name`
 
@@ -1622,6 +1623,14 @@ Data type: `Optional[Variant[String,Array[String]]]`
 Paramter as defined from varnish
 
 Default value: `undef`
+
+##### <a name="-varnish--vcl--probe--expected_response"></a>`expected_response`
+
+Data type: `Optional[String]`
+
+The expected HTTP status, defaults to '200'
+
+Default value: `'200'`
 
 ### <a name="varnish--vcl--selector"></a>`varnish::vcl::selector`
 

--- a/manifests/vcl/probe.pp
+++ b/manifests/vcl/probe.pp
@@ -20,6 +20,8 @@
 #   Paramter as defined from varnish
 # @param request
 #   Paramter as defined from varnish
+# @param expected_response
+#   The expected HTTP status, defaults to '200'
 define varnish::vcl::probe (
   String $interval  = '5s',
   String $timeout   = '5s',
@@ -28,10 +30,11 @@ define varnish::vcl::probe (
   String $includedir = $varnish::vcl::includedir,
   Optional[String] $url       = undef,
   Optional[Variant[String,Array[String]]] $request   = undef,
+  Optional[String] $expected_response = '200',
   Varnish::VCL::Ressource $probe_name = $title,
 ) {
   # parameters for probe
-  $probe_params = ['interval', 'timeout', 'threshold', 'window', 'url', 'request']
+  $probe_params = ['interval', 'timeout', 'threshold', 'window', 'url', 'request', 'expected_response']
 
   concat::fragment { "${title}-probe":
     target  => "${includedir}/probes.vcl",


### PR DESCRIPTION
#### Pull Request (PR) description
Add the `expected_response` parameter to the `varnish::vcl::probe` class, along with documentation in REFERENCE.md.

#### This Pull Request (PR) fixes the following issues
The `expected_response` probe parameter has been missing since the maxchk days and was therefore not configurable by this module.