### PR TITLE
Added max_connections option to a backend

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1387,6 +1387,7 @@ The following parameters are available in the `varnish::vcl::backend` defined ty
 * [`connect_timeout`](#-varnish--vcl--backend--connect_timeout)
 * [`first_byte_timeout`](#-varnish--vcl--backend--first_byte_timeout)
 * [`between_bytes_timeout`](#-varnish--vcl--backend--between_bytes_timeout)
+* [`max_connections`](#-varnish--vcl--backend--max_connections)
 * [`ssl`](#-varnish--vcl--backend--ssl)
 * [`ssl_sni`](#-varnish--vcl--backend--ssl_sni)
 * [`ssl_verify_peer`](#-varnish--vcl--backend--ssl_verify_peer)
@@ -1443,6 +1444,14 @@ Default value: `undef`
 Data type: `Optional[Variant[String[1],Integer]]`
 
 define varnish between_bytes_timeout
+
+Default value: `undef`
+
+##### <a name="-varnish--vcl--backend--max_connections"></a>`max_connections`
+
+Data type: `Optional[Integer]`
+
+define varnish maximum number of connections to the backend
 
 Default value: `undef`
 

--- a/manifests/vcl/backend.pp
+++ b/manifests/vcl/backend.pp
@@ -14,6 +14,8 @@
 #   define varnish first_byte_timeout
 # @param between_bytes_timeout
 #   define varnish between_bytes_timeout
+# @param max_connections
+#   define varnish maximum number of connections to the backend
 # @param ssl
 #   varnish-plus: Set this true (1) to enable SSL/TLS for this backend.
 # @param ssl_sni
@@ -33,6 +35,7 @@ define varnish::vcl::backend (
   Optional[Variant[String[1],Integer]] $connect_timeout       = undef,
   Optional[Variant[String[1],Integer]] $first_byte_timeout    = undef,
   Optional[Variant[String[1],Integer]] $between_bytes_timeout = undef,
+  Optional[Integer] $max_connections = undef,
   Optional[Integer[0,1]] $ssl = undef,
   Optional[Integer[0,1]] $ssl_sni = undef,
   Optional[Integer[0,1]] $ssl_verify_peer = undef,

--- a/templates/includes/backends.vcl.erb
+++ b/templates/includes/backends.vcl.erb
@@ -14,6 +14,9 @@ backend <%= @backend_name %> {
   <%- if @between_bytes_timeout -%>
   .between_bytes_timeout = <% if @between_bytes_timeout.is_a? Integer %><%= "#{@between_bytes_timeout}s" %><% else %><%= @between_bytes_timeout %><% end %>;
   <%- end -%>
+  <%- if @max_connections -%>
+  .max_connections = <%= @max_connections %>;
+  <%- end -%>
   <%- if @ssl -%>
   .ssl = <%= @ssl %>;
   <%- end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add max_connections option to varnish::vcl::backend to limit number of connections.

#### This Pull Request (PR) fixes the following issues
By default max_connections is 1000, which is too much for certain backends.