### PR TITLE
puppetlabs/stdlib: Require 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Fix #38
Due to last changes Stdlib > 9 is already required. Now also fixed in metadata