### PR TITLE
Add varnish pid file path configuration option

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -113,6 +113,7 @@ The following parameters are available in the `varnish` class:
 * [`manage_firewall`](#-varnish--manage_firewall)
 * [`varnish_conf_template`](#-varnish--varnish_conf_template)
 * [`conf_file_path`](#-varnish--conf_file_path)
+* [`varnish_pid_file_path`](#-varnish--varnish_pid_file_path)
 * [`additional_parameters`](#-varnish--additional_parameters)
 * [`default_version`](#-varnish--default_version)
 * [`add_hitch`](#-varnish--add_hitch)
@@ -414,6 +415,14 @@ Data type: `Stdlib::Absolutepath`
 path where varnish conf will be stored
 
 Default value: `'/etc/varnish/varnish.params'`
+
+##### <a name="-varnish--varnish_pid_file_path"></a>`varnish_pid_file_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+path where varnish will store its PID file
+
+Default value: `undef`
 
 ##### <a name="-varnish--additional_parameters"></a>`additional_parameters`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,8 @@
 #   Template that will be used for varnish conf
 # @param conf_file_path
 #   path where varnish conf will be stored
+# @param varnish_pid_file_path
+#   path where varnish will store its PID file
 # @param additional_parameters
 #   additional parameters that will be passed to varnishd with -p
 # @param default_version
@@ -82,7 +84,7 @@
 #   Add varnish::hitch class to install hitch
 # @param add_ncsa
 #   Add varnish::ncsa class to install varnishncsa Service
-# 
+#
 # @example Installs Varnish
 #   # enables Varnish service
 #   # uses default VCL '/etc/varnish/default.vcl'
@@ -136,6 +138,7 @@ class varnish (
   Boolean $manage_firewall      = false,
   String[1] $varnish_conf_template        = 'varnish/varnish-conf.erb',
   Stdlib::Absolutepath $conf_file_path  = '/etc/varnish/varnish.params',
+  Optional[Stdlib::Absolutepath] $varnish_pid_file_path = undef,
   Hash $additional_parameters        = {},
   Integer $default_version = 6,
   Boolean $add_hitch = false,

--- a/spec/classes/varnish_spec.rb
+++ b/spec/classes/varnish_spec.rb
@@ -57,6 +57,7 @@ describe 'varnish', type: :class do
       it { is_expected.to contain_file('varnish-conf').with_content(%r{VARNISH_TTL=120}) }
       it { is_expected.to contain_file('varnish-conf').with_content(%r{DAEMON_OPTS="-a :6081 }) }
       it { is_expected.not_to contain_file('varnish-conf').with_content(%r{-a /tmp/varnish.sock,PROXY,user=varnish,group=varnish,mode=666}) }
+      it { is_expected.not_to contain_file('varnish-conf').with_content(%r{-P /run/varnishd.pid}) }
 
       it {
         is_expected.to contain_file('storage-dir').with(
@@ -132,6 +133,15 @@ describe 'varnish', type: :class do
             'require' => 'Package[varnish]'
           )
         }
+      end
+
+      context 'with custom pid file' do
+        let :params do
+          { varnish_pid_file_path: '/run/varnishd.pid' }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_file('varnish-conf').with_content(%r{-P /run/varnishd.pid}) }
       end
 
       context 'without shmlog_tempfs' do

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -94,6 +94,9 @@ DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.looku
 <% if @varnish_proxy_listen_socket -%>
             -a <%= scope.lookupvar('varnish_proxy_listen_socket') %>,PROXY,user=<%= scope.lookupvar('varnish_user') -%>,group=<%= scope.lookupvar('varnish_group') -%>,mode=<%= scope.lookupvar('varnish_proxy_listen_socket_mode') %> \
 <% end -%>
+<% if @varnish_pid_file_path -%>
+             -P <%= scope.lookupvar('varnish_pid_file_path') %> \
+<% end -%>
              -f <%= scope.lookupvar('varnish_vcl_conf') %> \
              -T <%= scope.lookupvar('varnish_admin_listen_address') %>:<%= scope.lookupvar('varnish_admin_listen_port') %> \
              -t <%= scope.lookupvar('varnish_ttl') %> \


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds an additional configuration option to set the PID file path. If `undef` (default) no change is made. Useful for stability/consistency.

#### This Pull Request (PR) fixes the following issues
Fixes an issue when the default file path is incompatible with the system and needs to be reconfigured.
